### PR TITLE
Add external doc link in version navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -123,7 +123,7 @@ const config = {
           {
            type: 'docsVersionDropdown',
            position: 'left',
-           dropdownItemsAfter: [{to: '/versions', label: 'All versions'}],
+            dropdownItemsAfter: [{href: 'https://docs.foundries.io', label: 'All versions'}],
            dropdownActiveClassDisabled: true,
           },
           {


### PR DESCRIPTION
A link to our docs collection was added to the options under the nav for `versions`.
This was done to demonstrate how we could include older versions while having them decoupled from the main doc repo; overtime having all the docs versions in the repo could get cumbersome.

See the Jira issue for more details/discussion.

QA Steps: checked link for website via local dev server, no issues.

This commit addresses FFTK-2737