### PR TITLE
Test templating with qemu section

### DIFF
--- a/docs/reference-manual/qemu/_qemu-instructions.mdx
+++ b/docs/reference-manual/qemu/_qemu-instructions.mdx
@@ -1,0 +1,30 @@
+# Booting in QEMU
+
+:::info
+
+If you are using a prebuilt Target. your artifacts begin with ``lmp-base-console-image`` instead.
+
+:::
+
+<p> For {props.arch}: </p>
+
+
+<code>
+     └── | {props.arch} {'\n'}
+         ├── lmp-factory-image-{props.machine}.wic.gz {'\n'}
+         ├── other {'\n'}
+         │   └── lmp-factory-image-{props.machine}.wic.qcow2 # optional {'\n'}
+         └──{props.firmwareBlob}{'\n'}
+</code>
+
+## QEMU CLI
+
+<code>
+    {props.qemuCli}
+</code>
+
+:::tip
+
+You can register your device by following the steps from the [Getting Started Guide](getting/started/register-device/index.mdx).
+
+:::

--- a/docs/reference-manual/qemu/arm.mdx
+++ b/docs/reference-manual/qemu/arm.mdx
@@ -1,0 +1,19 @@
+# arm
+
+import QemuInstructions from './_qemu-instructions.mdx';
+
+<QemuInstructions
+  arch="arm"
+  machine="qemuarm"
+  firmwareBlob="u-boot-qemuarm.bin"
+  qemuCli="
+   qemu-system-arm -machine virt,highmem=off -cpu cortex-a7 -m 1024M \
+       -bios u-boot-qemuarm.bin \
+       -serial mon:vc -serial null \
+       -drive id=disk0,file=lmp-factory-image-qemuarm.wic,if=none,format=raw -device virtio-blk-device,drive=disk0 \
+       -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
+       -device virtio-net-device,netdev=usernet \
+       -netdev user,id=usernet,hostfwd=tcp::22222-:22 \
+       -no-acpi -d unimp -nographic
+"
+/>

--- a/docs/reference-manual/qemu/x86-64.mdx
+++ b/docs/reference-manual/qemu/x86-64.mdx
@@ -1,0 +1,15 @@
+# x86_64
+
+import QemuInstructions from './_qemu-instructions.mdx';
+
+<QemuInstructions
+  arch="x86_64"
+  machine="intel-corei7-64"
+  firmwareBlob="ovmf.secboot.qcow2"
+  qemuCli="
+qemu-system-x86_64 -m 1024 -cpu kvm64 -enable-kvm -serial mon:stdio -serial null \
+     -drive file=lmp-factory-image-intel-corei7-64.wic.qcow2,format=qcow2,if=none,id=hd \
+     -device virtio-scsi-pci,id=scsi -device scsi-hd,drive=hd -device virtio-rng-pci \
+     -drive if=pflash,format=qcow2,file=ovmf.secboot.qcow2 \
+     -net user,hostfwd=tcp::22223-:22 -net nic -nographic"
+/>

--- a/templates/qemu-template.mdx
+++ b/templates/qemu-template.mdx
@@ -1,0 +1,18 @@
+---
+id: qemu-ARCH
+tags:[qemu, flashing,]
+---
+
+# ARCH NAME HERE
+
+Copy this file as ARCH-NAME.mdx (such as "arm.mdx") into 
+`docs/reference-manaual/qemu/` and add values to vars below.
+
+import QemuInstructions from './_qemu-instructions.mdx';
+
+<QemuInstructions
+  arch=""
+  machine=""
+  firmwareBlob=""
+  qemuCli=""
+/>


### PR DESCRIPTION
Explored templating options via import options. While Docusaurus enables a number of options to do this, using MDX (markdown -> javascript) allows us to access passed data, which seemed to be the most straight forward. Where `arm.mdx` and `x86-64.mdx` can mostly be seen as lists of variables, the pass them to the "fragment", `_qemu-instructions.mdx` which serves as as the content template.

A template folder and file were also added.

QA Steps: checked rendered output, both "live" and "static". Created two files that use the template, no issues.

This commit addresses FFTK 2738